### PR TITLE
Keep otp underlines visible always

### DIFF
--- a/apps/client/app/(auth)/verify-otp.tsx
+++ b/apps/client/app/(auth)/verify-otp.tsx
@@ -350,8 +350,7 @@ export default function VerifyOtpScreen() {
                     )}
                     <View style={[
                       styles.digitUnderline,
-                      { backgroundColor: textColor, opacity: 0.3 },
-                      isActive && styles.digitUnderlineActive
+                      { backgroundColor: textColor, opacity: 0.3 }
                     ]} />
                   </View>
                 );
@@ -494,11 +493,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#F8CEAC',
     borderRadius: 1,
     opacity: 0.5,
-  },
-  
-  digitUnderlineActive: {
-    backgroundColor: '#FFEFE3',
-    opacity: 1,
   },
   
   // Hidden input (captures keyboard input)


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-891c339d-ca7f-4d59-9271-104565af9ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-891c339d-ca7f-4d59-9271-104565af9ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

